### PR TITLE
Fix typo in App.js

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -10,7 +10,7 @@ const App = () => {
       <div className="App-header">
         <h1>Template Picker</h1>
         <p>
-          Starting a site doesn't have to be hard, here are some examples to get you started. Add a new templates via <a href="https://github.com/bdougie/cms-templates">GitHub</a>
+          Starting a site doesn't have to be hard, here are some examples to get you started. Add a new template via <a href="https://github.com/bdougie/cms-templates">GitHub</a>
         </p>
       </div>
       <Templates />


### PR DESCRIPTION
**- Summary**

Removes the trailing 's' from "Add a new template[s]", which I believe to be a typo.

**- Test plan**

Not applicable.

**- Description for the changelog**

Removes the trailing 's' from "Add a new template[s]" in App.js

