### PR TITLE
Improves the order of content in narrow layout

### DIFF
--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -101,27 +101,40 @@ ul.listing {
     padding-left: 0em;
     @include bp(mid) {
     }
+
+    a.cta-title {
+      display: inline-block;
+      @include bp(mid) {
+        display: none;
+      }
+    }
   }
+
   div.right {
     padding-left: 0em;
     @include bp(mid) {
       padding-left: 2em;
     }
+
+    a.cta-title {
+      display: none;
+      @include bp(mid) {
+        display: inline;
+      }
+    }
   }
 
-   img.preview {
-     width: 100%;
-     margin-top: 0.5em;
-     margin-bottom: 1em;
-     -webkit-box-shadow: 0 1px 6px 0 rgba(14,30,37,.12);
-     box-shadow: 0 1px 6px 0 rgba(14,30,37,.12);
-   }
-
-  a.cta-title,
-  .template-title {
+  img.preview {
+    width: 100%;
+    margin-top: 0.5em;
     margin-bottom: 1em;
+    -webkit-box-shadow: 0 1px 6px 0 rgba(14,30,37,.12);
+    box-shadow: 0 1px 6px 0 rgba(14,30,37,.12);
   }
 
+  a.cta-title {
+    margin-bottom: 0.5em;
+  }
 }
 
 

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -102,10 +102,15 @@ ul.listing {
     @include bp(mid) {
     }
 
-    a.cta-title {
-      display: inline-block;
+    .cta-title-wrapper {
       @include bp(mid) {
+        margin-top: 0;
+        margin-bottom: 0;
         display: none;
+      }
+
+      a.cta-title {
+        display: inline-block;
       }
     }
   }
@@ -116,9 +121,18 @@ ul.listing {
       padding-left: 2em;
     }
 
-    a.cta-title {
+    .cta-title-wrapper {
+      margin-top: 0;
+      margin-bottom: 0;
       display: none;
+
       @include bp(mid) {
+        margin-top: 1em;
+        margin-bottom: 0.4em;
+        display: block;
+      }
+
+      a.cta-title {
         display: inline;
       }
     }

--- a/src/site/_includes/summary.njk
+++ b/src/site/_includes/summary.njk
@@ -7,6 +7,7 @@
 <div class="template-summary">
   <div class="box">
     <div class="left">
+      <h3><a class="cta-title" href="{{ item.url }}">{{ item.data.title }}</a></h3>
       <a class="cta-image" href="{{ item.url }}">
         <img class="thumbnail" src="/images/previews/{{ item.data.preview | appendToName('-400') }}" alt="Screenshot of a page created with {{ item.data.title }}" />
       </a>

--- a/src/site/_includes/summary.njk
+++ b/src/site/_includes/summary.njk
@@ -7,13 +7,17 @@
 <div class="template-summary">
   <div class="box">
     <div class="left">
-      <h3><a class="cta-title" href="{{ item.url }}">{{ item.data.title }}</a></h3>
+      <h3 class="cta-title-wrapper">
+        <a class="cta-title" href="{{ item.url }}">{{ item.data.title }}</a>
+      </h3>
       <a class="cta-image" href="{{ item.url }}">
         <img class="thumbnail" src="/images/previews/{{ item.data.preview | appendToName('-400') }}" alt="Screenshot of a page created with {{ item.data.title }}" />
       </a>
     </div>
     <div class="right">
-      <h3><a class="cta-title" href="{{ item.url }}">{{ item.data.title }}</a></h3>
+      <h3 class="cta-title-wrapper">
+        <a class="cta-title" href="{{ item.url }}">{{ item.data.title }}</a>
+      </h3>
       <ul class="meta tags">
         {%- for tag in item.data.tags -%}
         <li class="tag"><a href="/tags/{{tag}}">{{tag}}</a></li>


### PR DESCRIPTION
Closes #9 

**- Summary**

"The preview image appears before the name of the template which makes things less clear than they should be."

**- Test plan**

<img width="898" alt="Screen Shot 2019-07-15 at 5 18 22 PM" src="https://user-images.githubusercontent.com/1855345/61250009-9f9c6980-a724-11e9-8a03-13b6330cc626.png">

<img width="388" alt="Screen Shot 2019-07-15 at 5 18 38 PM" src="https://user-images.githubusercontent.com/1855345/61250008-9f9c6980-a724-11e9-83d3-7d09574406e9.png">


**- Description for the changelog**

The name of the template now appears above the preview image on the narrow view of the site.
