### PR TITLE
fix gatsby netlify cms starter link

### DIFF
--- a/src/site/template/gatsby-blog-with-netlify-cms.md
+++ b/src/site/template/gatsby-blog-with-netlify-cms.md
@@ -1,6 +1,6 @@
 ---
 title: Gatsby + Netlify CMS Starter
-repo: https://github.com/AustinGreen/gatsby-starter-netlify-cms
+repo: https://github.com/netlify-templates/gatsby-starter-netlify-cms
 stack: cms
 preview: gastby-netlify-cms-starter.jpg
 example: https://gatsby-netlify-cms.netlify.com


### PR DESCRIPTION
We ported this to our org with Austin's approval over a year ago, forgot to update this link.