### PR TITLE
Add Jamify Starter Blog - Powered by Next.js and Ghost CMS

### DIFF
--- a/src/site/template/next-cms-ghost.md
+++ b/src/site/template/next-cms-ghost.md
@@ -1,0 +1,18 @@
+---
+title: Jamify Starter Blog - Powered by Next.js and Ghost CMS
+repo: https://github.com/styxlab/next-cms-ghost
+preview: jamify-starter-ghost.png
+example: https://next.jamify.org/
+tags:
+  - jamify
+  - nextjs
+  - ghost
+  - react
+  - blog
+  - API
+  - starter
+---
+
+Publish flaring fast blogs with [NextJS](https://nextjs.org/) and [Ghost](https://ghost.org) CMS.
+
+Create and publish flaring fast blogs with this Jamify blogging system. Powered by the React framework Next.js and content fed by headleass Ghost, you'll get a production ready hybrid static & server rendered website that you can easily distribute globally. At the same time your content creators can continue to work with the Ghost authoring system as they used to. Fully open-source and easy to customize.


### PR DESCRIPTION
- Summary

    Adds the Next.js driven Jamify Starter Blog

- Test plan

    Test with: yarn; yarn build

- Description for the changelog

    Adds template Jamify Starter Blog

