### PR TITLE
fix(gulp): prevent `clean-build` from erroring when `dist` directory does not exist

### DIFF
--- a/gulp-tasks/clean.js
+++ b/gulp-tasks/clean.js
@@ -4,6 +4,6 @@ var clean   = require('gulp-clean');
 
 // cleanup the build output
 gulp.task('clean-build', function () {
-  return gulp.src(project.buildDest, {read: false})
+  return gulp.src(`${project.buildDest}/*`, {read: false})
     .pipe(clean());
 });


### PR DESCRIPTION


**- Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

Ensures `dist` directory exists before running `gulp clean-build`

Closes #135

**- Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

- Delete `dist` and run `yarn start`, confirm that no errors are thrown
- Stop site, and manually add a `temp.txt` to `dist`
- Run `yarn start`, confirm that no errors are thrown, and that `temp.txt` is deleted

**- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

fix(gulp): fix `gulp clean-build` on fresh install