### PR TITLE
Fix missing "what will this do" content

### DIFF
--- a/src/site/_includes/about-deploy-to-netlify.njk
+++ b/src/site/_includes/about-deploy-to-netlify.njk
@@ -1,0 +1,4 @@
+<h2 id="about-deploy-to-netlify">What happens when you click 'Deploy to Netlify'?</h2>
+<p>
+  Once you click the Deploy to Netlify button you’ll be dropped into a simple signup workflow. Connect your Git repository and hit save, and Netlify will deploy the site to a global content delivery network. You’ll receive a link to your live site’s URL.
+</p>

--- a/src/site/index.njk
+++ b/src/site/index.njk
@@ -15,7 +15,4 @@ tags:
 {%- endfor -%}
 </ul>
 
-<h2 id="about-deploy-to-netlify">What happens when you click 'Deploy to Netlify'?</h2>
-<p>
-  Once you click the Deploy to Netlify button you’ll be dropped into a simple signup workflow. Connect your Git repository and hit save, and Netlify will deploy the site to a global content delivery network. You’ll receive a link to your live site’s URL.
-</p>
+{% include "about-deploy-to-netlify.njk" %}

--- a/src/site/tag.njk
+++ b/src/site/tag.njk
@@ -21,3 +21,5 @@ layout: layouts/base.njk
   </li>
 {% endfor %}
 </ul>
+
+{% include "about-deploy-to-netlify.njk" %}


### PR DESCRIPTION

## Summary
This fixes #218 – a bug in which clicking `What will this do` on the Tag view does not provide any new information.

## Test plan
1. Open the deploy preview and navigate to a tag page (e.g. https://deploy-preview-219--templates.netlify.app/tags/netlifyCMS)
2. Click "What will this do?" next to the first template in the tag.
3. Verify that `#about-deploy-to-netlify` is appended to the current URL
4. Verify that the section `What happens when you click 'Deploy to Netlify'?` has scrolled into view

## Description for the changelog
Adds `What happens when you click 'Deploy to Netlify'?` explainer to the bottom of the tag page, so users who click "What will this do" will get the correct information.

