### PR TITLE
Update gatsby-starter-contentful to working links

### DIFF
--- a/src/site/template/gatsby-starter-contentful.md
+++ b/src/site/template/gatsby-starter-contentful.md
@@ -1,8 +1,8 @@
 ---
 title: Gatsby Contentful Starter blog
-repo: https://github.com/contentful-userland/gatsby-contentful-starter
+repo: https://github.com/contentful/starter-gatsby-blog
 preview: gatsby-starter-contentful.png
-example: https://contentful-userland.github.io/gatsby-contentful-starter/
+example: https://contentful.github.io/starter-gatsby-blog/
 tags:
   - react
   - gatsby


### PR DESCRIPTION
**- Summary**

Fixes #273 

**- Test plan**

- Open Deploy Preview
- Validate that the new repository is pointing to https://github.com/contentful/starter-gatsby-blog
- Validate that the new demo site points to https://contentful.github.io/starter-gatsby-blog/
- Validate that the DTN button points to the right GitHub repo and asks for Contentful keys

**- Description for the changelog**

Updates `gatsby-starter-contentful` links

